### PR TITLE
Update wsl2-rolling-kernel-modules-stable to 6.15.0

### DIFF
--- a/bucket/wsl2-rolling-kernel-modules-stable.json
+++ b/bucket/wsl2-rolling-kernel-modules-stable.json
@@ -1,12 +1,12 @@
 {
-    "version": "6.14.6",
+    "version": "6.15.0",
     "description": "Rolling Release Stable Kernel Modules for Windows Subsystem for Linux2 (WSL2)",
     "homepage": "https://github.com/Nevuly/WSL2-Linux-Kernel-Rolling",
     "license": "GPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Nevuly/WSL2-Linux-Kernel-Rolling/releases/download/linux-wsl-stable-6.14.6/bzImage-x86_64-addon.vhdx",
-            "hash": "5759b055d2501fbf9584358f21c8865a1d720eee1ef3d78392928ba9b41c7c1e",
+            "url": "https://github.com/Nevuly/WSL2-Linux-Kernel-Rolling/releases/download/linux-wsl-stable-$version/bzImage-x86_64-addon.vhdx",
+            "hash": "c6b33a274969d37280e1c6ee56b60d18494746f24449a7831ae76a16ef418fe7",
             "post_install": [
                 "###########################################",
                 "# Set WSL2 rolling kernel modules in `.wslconfig` #",
@@ -31,8 +31,8 @@
             ]
         },
         "arm64": {
-            "url": "https://github.com/Nevuly/WSL2-Linux-Kernel-Rolling/releases/download/linux-wsl-stable-6.14.6/Image-arm64-addon.vhdx",
-            "hash": "976661901fc557039ca0992ceec0a05ab6ccfcee5014b59b42ace415c6caee73",
+            "url": "https://github.com/Nevuly/WSL2-Linux-Kernel-Rolling/releases/download/linux-wsl-stable-$version/Image-arm64-addon.vhdx",
+            "hash": "8aebb41934836f55141c756ec4a58668b6469dcecc86dd617c4bf33b0540055b",
             "post_install": [
                 "###########################################",
                 "# Set WSL2 rolling kernel modules in `.wslconfig` #",


### PR DESCRIPTION
6.15.0

- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
